### PR TITLE
Enable reload of whole form with new values

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -53,6 +53,9 @@ class Form extends React.Component {
   }
 
   render() {
+    if(this.props.reload == true){
+	this.state.formData = this.props.initialData;
+    }
     return (
       <form ref="form" className={this.props.className} onSubmit={this.onSubmit}>
 	       {this.props.children}


### PR DESCRIPTION
I have a master-detail configuration.  Detail uses this Form component. When i select a row in master, Form fills correctly by setting initialData.  When i select any other row form keeps showing old values that were fed via initialData.  I am proposing this patch as now we can set a Form property that can let us use form in both modes.  With reload property set to true. Form shows data of next row fed via initiaData

```
<Form  initialData={this.props.data}  onSubmit={this.handleForm} reload={true}>
    {this.createFields(this.props.data)}
</Form>
```
